### PR TITLE
Correct issues in DP1.10043.001 table join instructions

### DIFF
--- a/DP1.10043.001/Table.joining.md
+++ b/DP1.10043.001/Table.joining.md
@@ -1,24 +1,24 @@
 |Table 1|Table 2|Join by field(s)|
 |------------------------|------------------------|-------------------------------|
 mos_trapping|mos_sorting|sampleID
-mos_sorting|mos_subsampling|subsampleID
-mos_trapping|mos_subsampling|Requires intermediate table: join via mos_sorting table
+mos_sorting|mos_subsampling|Requires intermediate table: join via mos_expertTaxonomistID table (either Processed or Raw)
+mos_trapping|mos_subsampling|Requires intermediate table: join via mos\_sorting table and mos\_expertTaxonomistID table (either Processed or Raw)
 mos_sorting|mos_expertTaxonomistIDProcessed|subsampleID
 mos_sorting|mos_expertTaxonomistIDRaw|subsampleID
 mos_expertTaxonomistIDProcessed|mos_archivepooling|Requires intermediate table: join via mos_subsampling table
 mos_expertTaxonomistIDRaw|mos_archivepooling|Requires intermediate table: join via mos_subsampling table
-mos_archivepooling|mos_barcoding|Requires intermediate table: join via mos_subsampling table
-mos_archivepooling|mos_sorting|Requires intermediate table: join via mos_subsampling table
+mos_archivepooling|mos_barcoding|Full join not recommended: tables not related
+mos_archivepooling|mos_sorting|Requires intermediate table: join via mos\_sorting table and mos\_expertTaxonomistID table (either Processed or Raw) and mos\_subsampling table
 mos_archivepooling|mos_subsampling|archiveID
-mos_archivepooling|mos_trapping|Requires intermediate table: join via mos\_sorting and mos\_subsampling tables
-mos_barcoding|mos_expertTaxonomistIDProcessed|Requires intermediate table: join via mos_sorting table
-mos_barcoding|mos_expertTaxonomistIDRaw|Requires intermediate table: join via mos_sorting table
-mos_barcoding|mos_sorting|Requires intermediate table: join via mos_subsampling table
+mos_archivepooling|mos_trapping|Requires intermediate table: join via mos\_sorting and  mos\_expertTaxonomistID table (either Processed or Raw) and mos\_subsampling tables
+mos_barcoding|mos_expertTaxonomistIDProcessed|Not fully automatable: multiple individualIDs pooled into each individualIDList
+mos_barcoding|mos_expertTaxonomistIDRaw|Not fully automatable: multiple individualIDs pooled into each individualIDList
+mos_barcoding|mos_sorting|Not fully automatable: multiple individualIDs pooled into each individualIDList
 mos_barcoding|mos_subsampling|Not fully automatable: multiple individualIDs pooled into each individualIDList
-mos_barcoding|mos_trapping|Requires intermediate table: join via mos\_sorting and mos\_subsampling tables
-mos_expertTaxonomistIDProcessed|mos_expertTaxonomistIDRaw|subsampleID
-mos_expertTaxonomistIDProcessed|mos_subsampling|subsampleID
+mos_barcoding|mos_trapping|Not fully automatable: multiple individualIDs pooled into each individualIDList
+mos_expertTaxonomistIDProcessed|mos_expertTaxonomistIDRaw|subsampleID,scientificName,sex
+mos_expertTaxonomistIDProcessed|mos_subsampling|subsampleID,scientificName,sex
 mos_expertTaxonomistIDProcessed|mos_trapping|Requires intermediate table: join via mos_sorting table
-mos_expertTaxonomistIDRaw|mos_subsampling|subsampleID
+mos_expertTaxonomistIDRaw|mos_subsampling|subsampleID,scientificName,sex
 mos_expertTaxonomistIDRaw|mos_trapping|Requires intermediate table: join via mos_sorting table
-mos_identificationHistory|Any other table|Full join not recommended: Previous identifications of the same individual can be linked by identificationHistoryID
+mos_identificationHistory|Any other table|Full join not recommended: Previous identifications of the same individual can be linked by identificationHistoryID in the mos\_expertTaxonomistID table (either Processed or Raw)

--- a/qsg-template.md
+++ b/qsg-template.md
@@ -103,6 +103,11 @@
 ## Collection methodology
 {{. Collection.methodology }}
 
+{{if REPO.FILE [Maintenance.and.calibration] }}
+## Maintenance and calibration
+{{. Maintenance.and.calibration }}  
+{{end}}
+
 {{# .Images }}  
 {{. Image# }}  
 {{. Image.legend# }}  


### PR DESCRIPTION
Update table join instructions to reflect the desired table join format which is: trapping to sorting via sampleID, sorting to one of the ID tables via subsampleID, one of the ID tables to subsample table via combined subsampleID, scientificName and sex fields, subsample table to archive pooling table via archiveID.  Since the sampleIDs in the barcoding table are in list format change all to indicate not fully automatable