### PR TITLE
Update join of pathogen testing to trapping

### DIFF
--- a/DP1.10064.002/Table.joining.md
+++ b/DP1.10064.002/Table.joining.md
@@ -1,4 +1,4 @@
 |Table 1|Table 2|Join by field Table 1|Join by field Table 2|
 |------------------|-------------------|--------------------|---------------------|
-rpt2_pathogentesting|mam_pertrapnight|sampleID|bloodSampleID, earSampleID
+rpt2_pathogentesting|mam_pertrapnight|sampleID|Not fully automatable: pathogen testing results should be filtered to sampleIDs ending in either .E or .B and joined to mammal data via the earSampleID or via the bloodSampleID respectively.
 rpt2_pathogentesting|rpt2_pathogenqa|batchID|batchID

--- a/DP1.10072.001/Table.joining.md
+++ b/DP1.10072.001/Table.joining.md
@@ -1,5 +1,5 @@
 |Table 1|Table 2|Join by field(s)|
 |------------------------|------------------------|-------------------------------|
 mam_perplotnight|mam_pertrapnight|nightuid
-mam_pertrapnight|mam_voucher|voucherSampleID
+mam_pertrapnight|mam_voucher|Full join not recommended: tables not related. Vouchers listed here reflect vouchers collected outside of normal mammal trapping activities during other NEON sampling protocols.
 mam_perplotnight|mam_voucher|Requires intermediate table: Join via mam_pertrapnight table.


### PR DESCRIPTION
Show that pathogen testing data are joined to two possible columns in mammal trapping data - either bloodSampleID or earSampleID