### PR TITLE
Update Table.joining.md

### DIFF
--- a/DP1.10058.001/Table.joining.md
+++ b/DP1.10058.001/Table.joining.md
@@ -1,6 +1,8 @@
 |Table 1|Table 2|Join by field(s)|
 |------------------------|------------------------|-------------------------------|
 div_1m2Data|div_10m2Data100m2Data|Direct join not recommended. See Standard calculations.
-div_geneticarchive|Any other table|Join not recommended. Data resolution does not match other tables.
+div_1m2Data|div_morphospecies|siteID and morphospeciesID
+div_10m2Data100m2Data|div_morphospecies|siteID and morphospeciesID
 div_morphospecies|Any other table|Join not recommended. Data resolution does not match other tables.
+div_geneticarchive|Any other table|Join not recommended. Data resolution does not match other tables.
 div_voucher|Any other table|Join not recommended. Data resolution does not match other tables.


### PR DESCRIPTION
Hi Claire,  

The morphospecies table can and should be joined to the tables that result from the plot tables - div_1m2Data and div_10m2Data100m2Data.  This is how end users can incorporate those species that were not identified in the field but were resolved in the lab.  

-The full_join makes good sense, but unfortunately it does not (obviously) replace the new scientificName and taxonID in the data but adds the y.scientificName and y.taxonID.  I think this is fine, just would be great if we could be more elegant.  Perhaps that would be another script we could create?

-As of now, there are no duplicate morphospeciesID records across sites, but it could happen.  Given that many users will be working with multiple sites, the join needs to include siteID.  Alternatively, if double joins present excessive complexity, I think Fulcrum can append the siteID to the morph name when the record is created.  The join could then be on morphospeciesID.

-I have a function that links the div_1m2Data and the div_10m2Data100m2Data tables.  Maybe that can be included in the join tables function you are working on?  Perhaps we should meet to discuss.