### PR TITLE
added note to deprecated mcc qsg

### DIFF
--- a/DP1.10081.001/Measurement.txt
+++ b/DP1.10081.001/Measurement.txt
@@ -1,1 +1,1 @@
-Taxonomic identification data for bacterial, archaeal, and fungal communities in soils
+Taxonomic identification data for bacterial, archaeal, and fungal communities in soils. NOTE: This data product has been deprecated and is being replaced by Soil microbe community taxonomy (DP1.10081.002). Please refer to this data product for details on samples, data analysis, and guides for use.

--- a/DP1.20086.001/Measurement.txt
+++ b/DP1.20086.001/Measurement.txt
@@ -1,1 +1,1 @@
-Taxonomic identification data for bacterial, archaeal, and fungal communities in benthic sediments
+Taxonomic identification data for bacterial, archaeal, and fungal communities in benthic sediments. NOTE: This data product has been deprecated and is being replaced by Benthic microbe community taxonomy (DP1.20286.002). Please refer to this data product for details on samples, data analysis, and guides for use.

--- a/DP1.20141.001/Measurement.txt
+++ b/DP1.20141.001/Measurement.txt
@@ -1,1 +1,1 @@
-Taxonomic identification data for bacterial, archaeal, and fungal communities in surface water
+Taxonomic identification data for bacterial, archaeal, and fungal communities in surface water. NOTE: This data product has been deprecated and is being replaced by Surface Water microbe community taxonomy (DP1.20141.002). Please refer to this data product for details on samples, data analysis, and guides for use.


### PR DESCRIPTION
Added short note to Measurement.txt for deprecated MCC Quick start guides to indicate that this DP has been deprecated and MCT is the new one. Done for benthic (DP1.20086.001), soil (DP1.10081.001), and surface (DP1.20141.001). 